### PR TITLE
Fix spelling of "Connectivity" in Azure IoT query

### DIFF
--- a/Azure Services/IoT Hub/Queries/Errors/Connectvity errors.kql
+++ b/Azure Services/IoT Hub/Queries/Errors/Connectvity errors.kql
@@ -1,5 +1,5 @@
 // Author: Microsoft Azure
-// Display name: Connectvity errors
+// Display name: Connectivity errors
 // Description: Identify device connection errors.
 // Categories: Azure Resources
 // Resource types: IoT Hub


### PR DESCRIPTION
I came across this spelling error of "Connectivity errors" in normal usage of Azure IoT portal