### PR TITLE
Update Slowest queries.kql

### DIFF
--- a/Azure Services/Azure Database for PostgreSQL servers/Queries/Performance/Slowest queries.kql
+++ b/Azure Services/Azure Database for PostgreSQL servers/Queries/Performance/Slowest queries.kql
@@ -9,5 +9,5 @@ AzureDiagnostics
 | where ResourceProvider == "MICROSOFT.DBFORPOSTGRESQL"
 | where Category == "QueryStoreRuntimeStatistics"
 | where user_id_s != "10" //exclude azure system user
-| summarize avg(todouble(mean_time_s)) by event_class_s , db_id_s ,query_id_d
+| summarize avg(todouble(mean_time_s)) by db_id_s ,query_id_d
 | top 5 by avg_mean_time_s desc


### PR DESCRIPTION
QueryStoreRuntimeStatistics does not have the event_class_s column, and in some environments, this column generates an error.
https://docs.microsoft.com/en-us/azure/postgresql/concepts-query-store#querystoreruntimestatistics