### PR TITLE
Adjust CDN Profile OperationName and Category

### DIFF
--- a/Azure Services/CDN profiles/Queries/Usage/Top 10 URL request count.kql
+++ b/Azure Services/CDN profiles/Queries/Usage/Top 10 URL request count.kql
@@ -9,8 +9,7 @@
 // Render line chart showing total requests per hour . 
 // Summarize number of requests per hour 
 AzureDiagnostics
-| where OperationName == "Microsoft.Cdn/Profiles/AccessLog/Write" and Category == "AzureCdnAccessLog" 
-| where isReceivedFromClient_b == true
-| summarize UserRequestCount = count() by requestUri_s
-| order by UserRequestCount
-| limit 10
+ | where ResourceProvider == "MICROSOFT.CDN" and Category == "FrontDoorAccessLog"
+ | summarize UserRequestCount = count() by requestUri_s
+ | order by UserRequestCount
+ | limit 10


### PR DESCRIPTION
I have noticed that OperationName and Category for CDN profiles have changed.
This is how it works for my current standard Front Door deployment.
