### PR TITLE
Added a set of Queries/Alerts dealing with NSGs

### DIFF
--- a/Azure Services/Azure Activity logs/Alerts/README
+++ b/Azure Services/Azure Activity logs/Alerts/README
@@ -1,1 +1,4 @@
 Put alerts in this folder
+
+## deployNSGAlert.json
+Since json doesn't have comments, I'll put them here. This ARM would deploy the alert to go with the two parameters files that start with the deployNSGAlert.

--- a/Azure Services/Azure Activity logs/Alerts/deployNSGAlert.json
+++ b/Azure Services/Azure Activity logs/Alerts/deployNSGAlert.json
@@ -1,0 +1,143 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "alertName": {
+        "type": "string",
+        "metadata": {
+          "description": "Name of the Azure Monitor alert"
+        }
+      },
+      "alertDescription": {
+        "type": "string",
+        "metadata": {
+          "description": "Description of the Azure Monitor alert"
+        }
+      },
+      "query": {
+        "type": "string",
+        "metadata": {
+          "description": "Log Analytics Kusto query that is used for the alert"
+        }
+      },
+      "evaluationFrequency": {
+        "type": "int",
+        "minValue": 5,
+        "maxValue": 1440,
+        "metadata": {
+          "description": "The frequency (in minutes) at which rule condition should be evaluated."
+        }
+      },
+      "timeWindow": {
+        "type": "int",
+        "minValue": 5,
+        "maxValue": 1440,
+        "metadata": {
+          "description": "Time window (in minutes) for which data needs to be fetched for query (should be greater than or equal to evaluationFrequency value)."
+        }
+      },
+      "threshold": {
+        "type": "int",
+        "defaultValue": 0,
+        "metadata": {
+          "description": "Result or count threshold based on which rule should be triggered."
+        }
+      },
+      "operator": {
+        "type": "string",
+        "defaultValue": "GreaterThan",
+        "allowedValues": [
+          "Equal",
+          "GreaterThan",
+          "LessThan"
+        ],
+        "metadata": {
+          "description": "Result Condition Evaluation criteria"
+        }
+      },
+      "throttling": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 10000,
+        "metadata": {
+          "description": "Time (in minutes) for which Alerts should be throttled or suppressed. To disable set it 0"
+        }
+      },
+      "severity": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 4,
+        "metadata": {
+          "description": "Severity Level of Alert. 0 - Critical, 1 - Error, 2 - Warning, 3 - Informational, 4 - Verbose"
+        }
+      },
+      "actionGroupResourceIds": {
+        "type": "array",
+        "metadata": {
+          "description": "The list of resource Id of the action groups that receive notifiction when the alert is generated"
+        }
+      },
+      "logAnalyticsWorkspaceResourceId": {
+        "type": "string",
+        "metadata": {
+          "description": "The resource Id of the Log Analytics workspace the log search query is to be run."
+        }
+      },
+      "logAnalyticsWorkspaceLocation": {
+        "type": "string",
+        "metadata": {
+          "description": "The location of the log analytics workspace"
+        }
+      },
+      "isEnabled": {
+        "type": "bool",
+        "metadata": {
+          "description": "The flag to whether enable this alert."
+        }
+      }
+    },
+    "variables": {
+      "alertName": "[concat('azure', '-', parameters('alertName'), '-alert')]"
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Insights/scheduledQueryRules",
+        "apiVersion": "2018-04-16",
+        "name": "[variables('alertName')]",
+        "location": "[parameters('logAnalyticsWorkspaceLocation')]",
+        "properties": {
+          "description": "[parameters('alertDescription')]",
+          "enabled": "[parameters('isEnabled')]",
+          "source": {
+            "query": "[parameters('query')]",
+            "dataSourceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+            "queryType": "ResultCount"
+          },
+          "schedule": {
+            "frequencyInMinutes": "[parameters('evaluationFrequency')]",
+            "timeWindowInMinutes": "[parameters('timeWindow')]"
+          },
+          "action": {
+            "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
+            "severity": "[parameters('severity')]",
+            "aznsAction": {
+              "actionGroup": "[parameters('actionGroupResourceIds')]",
+              "emailSubject": "[concat(' Alert:', concat(' [', subscription().displayName ,'] '),parameters('alertName'))]"
+  
+            },
+            "throttlingInMin": "[parameters('throttling')]",
+            "trigger": {
+              "thresholdOperator": "[parameters('operator')]",
+              "threshold": "[parameters('threshold')]"
+            }
+          }
+        }
+      }
+    ],
+    "outputs": {
+      "resourceId": {
+        "type": "string",
+        "value": "[resourceId('Microsoft.Insights/scheduledQueryRules', variables('alertName'))]"
+      }
+    }
+  }

--- a/Azure Services/Azure Activity logs/Alerts/deployNSGAlertCreate.parameters.json
+++ b/Azure Services/Azure Activity logs/Alerts/deployNSGAlertCreate.parameters.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "alertName": {
+        "value": "nsg-inbound-rule-create-to-allow-all"
+      },
+      "alertDescription": {
+        "value": "This alert is used to monitor and alert if someone updates NSG inbound rule to allow All (*)."
+      },
+      "query": {
+        "value": "AzureActivity \n| where OperationNameValue =~ \"Microsoft.Network/networkSecurityGroups/write\"\n| where ActivityStatusValue == \"Accept\"\n| extend Test_ = todynamic(parse_json(tostring(parse_json(tostring(Properties_d.responseBody)).properties)).securityRules) \n| mv-expand Test_ \n| extend SourceAddressPrefix_ = tostring(parse_json(tostring(parse_json(tostring(Test_)).properties)).sourceAddressPrefix) \n| extend SourceAddressPrefixes_ = tostring(parse_json(tostring(parse_json(tostring(Test_)).properties)).sourceAddressPrefixes) \n| extend Access = tostring(parse_json(tostring(parse_json(tostring(Test_)).properties)).access) \n | extend Port = tostring(parse_json(tostring(parse_json(tostring(Test_)).properties)).destinationPortRange) \n| where SourceAddressPrefix_ == '*' or SourceAddressPrefixes_ == '' or SourceAddressPrefixes_ == '0.0.0.0/0' \n| where Access == \"Allow\"\n| extend NsgName = split(_ResourceId, '/')[8] \n| extend NsgRule = split(_ResourceId, '/')[10] \n| project TimeGenerated, \n          NsgName, \n          NsgRule, \n          ResourceGroup, \n          SourceAddressPrefix_, \n          SourceAddressPrefixes_,\n         Port,\n         Caller,\n          CallerIpAddress"
+      },
+      "evaluationFrequency": {
+        "value": 5
+      },
+      "timeWindow": {
+        "value": 15
+      },
+      "threshold": {
+        "value": 0
+      },
+      "operator": {
+        "value": "GreaterThan"
+      },
+      "throttling": {
+        "value": 0
+      },
+      "severity": {
+        "value": 0
+      },
+      "actionGroupResourceIds": {
+        "value": [
+          "<insert action groups>"
+        ]
+      },
+      "logAnalyticsWorkspaceResourceId": {
+        "value": "<insert workspace ID"
+      },
+      "logAnalyticsWorkspaceLocation": {
+        "value": "<insert location>"
+      },
+      "isEnabled": {
+        "value": true
+      }
+    }
+  }

--- a/Azure Services/Azure Activity logs/Alerts/deployNSGAlertUpdate.parameters.json
+++ b/Azure Services/Azure Activity logs/Alerts/deployNSGAlertUpdate.parameters.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "alertName": {
+        "value": "nsg-inbound-rule-update-to-allow-all"
+      },
+      "alertDescription": {
+        "value": "This alert is used to monitor and alert if someone updates NSG inbound rule to allow All (*)."
+      },
+      "query": {
+        "value": "AzureActivity \n| where OperationNameValue =~ \"Microsoft.Network/networkSecurityGroups/securityRules/write\"\n| where ActivityStatusValue == \"Accept\"\n| extend SourceAddressPrefix_ = tostring(parse_json(tostring(parse_json(tostring(Properties_d.responseBody)).properties)).sourceAddressPrefix) \n| extend SourceAddressPrefixes_ = tostring(parse_json(tostring(parse_json(tostring(Properties_d.requestbody)).properties)).sourceAddressPrefixes)\n| extend Access = tostring(parse_json(tostring(parse_json(tostring(parse_json(Properties).responseBody)).properties)).access)\n | extend Port = tostring(parse_json(tostring(parse_json(tostring(parse_json(Properties).responseBody)).properties)).destinationPortRange) \n| where SourceAddressPrefix_ == '*' or SourceAddressPrefixes_ == '' or SourceAddressPrefixes_ == '0.0.0.0/0' \n| where Access == \"Allow\"\n| extend NsgName = split(_ResourceId, '/')[8] \n| extend NsgRule = split(_ResourceId, '/')[10] \n| project TimeGenerated, \n          NsgName, \n          NsgRule, \n          ResourceGroup, \n          SourceAddressPrefix_, \n          SourceAddressPrefixes_,\n         Port,\n          Caller,\n          CallerIpAddress"
+      },
+      "evaluationFrequency": {
+        "value": 5
+      },
+      "timeWindow": {
+        "value": 15
+      },
+      "threshold": {
+        "value": 0
+      },
+      "operator": {
+        "value": "GreaterThan"
+      },
+      "throttling": {
+        "value": 0
+      },
+      "severity": {
+        "value": 0
+      },
+      "actionGroupResourceIds": {
+        "value": [
+          "<insert action groups>"
+        ]
+      },
+      "logAnalyticsWorkspaceResourceId": {
+        "value": "<insert workspace ID>"
+      },
+      "logAnalyticsWorkspaceLocation": {
+        "value": "<insert location>"
+      },
+      "isEnabled": {
+        "value": true
+      }
+    }
+  }

--- a/Azure Services/Azure Activity logs/Queries/Activity logs/NSGCreateOpenAllowAll.kql
+++ b/Azure Services/Azure Activity logs/Queries/Activity logs/NSGCreateOpenAllowAll.kql
@@ -1,0 +1,24 @@
+// This Query returns NSGs with rules open to the internet at VM creation (where VM and NSG are created together)
+AzureActivity 
+| where OperationNameValue =~ "Microsoft.Network/networkSecurityGroups/write"
+    and ActivityStatusValue == "Accept"
+| extend SecurityRules_ = todynamic(parse_json(tostring(parse_json(tostring(Properties_d.responseBody)).properties)).securityRules)
+| mv-expand SecurityRules_
+| extend SourceAddressPrefix_ = tostring(parse_json(tostring(parse_json(tostring(SecurityRules_)).properties)).sourceAddressPrefix) 
+| extend SourceAddressPrefixes_ = tostring(parse_json(tostring(parse_json(tostring(SecurityRules_)).properties)).sourceAddressPrefixes)
+| extend Access = tostring(parse_json(tostring(parse_json(tostring(SecurityRules_)).properties)).access)
+| extend Port = tostring(parse_json(tostring(parse_json(tostring(SecurityRules_)).properties)).destinationPortRange)
+| where SourceAddressPrefix_ == '*' or SourceAddressPrefixes_ == '' or SourceAddressPrefixes_ == '0.0.0.0/0' 
+| where Access == "Allow"
+| extend NsgName = split(_ResourceId, '/')[8] 
+| extend NsgRule = split(_ResourceId, '/')[10] 
+| project TimeGenerated, 
+          NsgName, 
+          NsgRule, 
+          ResourceGroup, 
+          SourceAddressPrefix_, 
+          SourceAddressPrefixes_,
+		  Port,
+          Caller,
+          CallerIpAddress
+		  

--- a/Azure Services/Azure Activity logs/Queries/Activity logs/NSGUpdateOpenAllowAll.kql
+++ b/Azure Services/Azure Activity logs/Queries/Activity logs/NSGUpdateOpenAllowAll.kql
@@ -1,0 +1,23 @@
+// This Query returns NSGs with rules that have been updated
+AzureActivity 
+| where OperationNameValue =~ "Microsoft.Network/networkSecurityGroups/securityRules/write"
+| where ActivityStatusValue == "Accept"
+| extend SourceAddressPrefix_ = tostring(parse_json(tostring(parse_json(tostring(Properties_d.responseBody)).properties)).sourceAddressPrefix) 
+| extend SourceAddressPrefixes_ = tostring(parse_json(tostring(parse_json(tostring(Properties_d.requestbody)).properties)).sourceAddressPrefixes)
+| extend Access = tostring(parse_json(tostring(parse_json(tostring(parse_json(Properties).responseBody)).properties)).access)
+| extend Port = tostring(parse_json(tostring(parse_json(tostring(parse_json(Properties).responseBody)).properties)).destinationPortRange) 
+| where SourceAddressPrefix_ == '*'
+    or SourceAddressPrefixes_ == ''
+    or SourceAddressPrefixes_ == '0.0.0.0/0' 
+| where Access == "Allow"
+| extend NsgName = split(_ResourceId, '/')[8] 
+| extend NsgRule = split(_ResourceId, '/')[10] 
+| project TimeGenerated, 
+    NsgName, 
+    NsgRule, 
+    ResourceGroup, 
+    SourceAddressPrefix_, 
+    SourceAddressPrefixes_,
+    Port,
+    Caller,
+    CallerIpAddress


### PR DESCRIPTION
I have created a set of queries to return when NSGs are open to the Internet. There are two, one for when an NSG is updated to provide an open inbound rule and one for when the NSG is created. The schema is different depending on which operation is called. I also included two alerts ARM templates to alert on the two different queries.

To get cross subscription info, make  sure you ship your ActivityLogs to a central log analytics workspace. 