### PR TITLE
Make changes to Node & Controlplane workbook

### DIFF
--- a/Azure Services/Azure Operator Distributed Services/Workbooks/Preview/armTemplates/templates/controlplane.json
+++ b/Azure Services/Azure Operator Distributed Services/Workbooks/Preview/armTemplates/templates/controlplane.json
@@ -73,6 +73,7 @@
                 "name": "Timeframe",
                 "type": 4,
                 "isRequired": true,
+                "isGlobal": true,
                 "value": {
                   "durationMs": 2419200000
                 },
@@ -151,6 +152,7 @@
                 "version": "KqlParameterItem/1.0",
                 "name": "DailyCap",
                 "type": 1,
+                "isGlobal": true,
                 "query": "resources\r\n| where type =~ 'microsoft.operationalinsights/workspaces' \r\n| where '{Resource:name}' has name\r\n| project DailyQuotaGB  = trim(' ', tostring(properties.workspaceCapping.dailyQuotaGb))\r\n| project DailyQuotaGB = iff(DailyQuotaGB==\"-1.0\", \"Not set\", DailyQuotaGB)",
                 "crossComponentResources": ["{Resource}"],
                 "isHiddenWhenLocked": true,
@@ -260,7 +262,7 @@
                       "multiSelect": true,
                       "quote": "'",
                       "delimiter": ",",
-                      "query": "Usage\r\n| where TimeGenerated > ago(30d)\r\n| summarize IngestionVolume=sum(Quantity) by DataType\r\n| top 5 by IngestionVolume\r\n| project DataType, label=DataType, selected=1",
+                      "query": "Usage\r\n| summarize IngestionVolume=sum(Quantity) by DataType\r\n| top 5 by IngestionVolume\r\n| project DataType, label=DataType, selected=1",
                       "typeSettings": {
                         "additionalResourceOptions": ["value::5"],
                         "showDefault": false
@@ -1365,7 +1367,7 @@
                 "type": 3,
                 "content": {
                   "version": "KqlItem/1.0",
-                  "query": "KubePodInventory\r\n| where Name has strcat(\"{Application}\",\"-\")\r\n| where Computer in ({Computer})\r\n| distinct Computer, Namespace, Name, _ResourceId, ContainerStatus, ContainerID",
+                  "query": "KubePodInventory\r\n| where Name has strcat(\"{Application}\",\"-\")\r\n| where Computer in ({Computer})\r\n| extend PodName = Name\r\n| distinct Computer, Namespace, PodName, ContainerName, _ResourceId, ContainerStatus, ContainerStatusReason, ContainerID",
                   "size": 0,
                   "aggregation": 3,
                   "title": "Container Status",
@@ -1393,18 +1395,41 @@
                               "text": "{0}{1}"
                             },
                             {
-                              "operator": "==",
+                              "thresholdValue": "waiting",
+                              "representation": "pending",
                               "text": "{0}{1}"
                             },
                             {
-                              "thresholdValue": "waiting",
-                              "representation": "pending",
+                              "operator": "==",
+                              "thresholdValue": "terminated",
+                              "representation": "disabled",
                               "text": "{0}{1}"
                             },
                             {
                               "operator": "Default",
                               "thresholdValue": null,
                               "representation": "more",
+                              "text": "{0}{1}"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "columnMatch": "ContainerStatusReason",
+                        "formatter": 18,
+                        "formatOptions": {
+                          "thresholdsOptions": "icons",
+                          "thresholdsGrid": [
+                            {
+                              "operator": "==",
+                              "thresholdValue": "Completed",
+                              "representation": "success",
+                              "text": "{0}{1}"
+                            },
+                            {
+                              "operator": "Default",
+                              "thresholdValue": null,
+                              "representation": "Blank",
                               "text": "{0}{1}"
                             }
                           ]
@@ -1470,7 +1495,7 @@
                 "type": 3,
                 "content": {
                   "version": "KqlItem/1.0",
-                  "query": "let row = dynamic({row});\r\nKubePodInventory\r\n| where Name has strcat(\"{Application}\", \"-\")\r\n| where Computer in ({Computer})\r\n| where '{row}' == '{}' or (Name == row.PodName)\r\n//| where TimeGenerated >= ago(startDateTime)\r\n| where Namespace in('default', 'kube-system', 'nc-system') // and ControllerKind == 'ReplicaSet' // the system namespace filter goes here\r\n| distinct\r\n    ClusterName,\r\n    Computer,\r\n    PodUid,\r\n    TimeGenerated,\r\n    PodStatus,\r\n    ServiceName,\r\n    PodLabel,\r\n    Namespace,\r\n    ContainerStatus,\r\n    Name,\r\n    ControllerKind\r\n| summarize\r\n    arg_max(TimeGenerated, *),\r\n    TotalPODCount = count(),\r\n    podCount = sumif(1, PodStatus == 'Running' or PodStatus != 'Running'),\r\n    containerNotrunning = sumif(1, ContainerStatus != 'running')\r\n    by\r\n    ClusterName,\r\n    TimeGenerated,\r\n    ServiceName,\r\n    PodLabel,\r\n    Namespace,\r\n    Name,\r\n    ControllerKind\r\n| project\r\n    ClusterName,\r\n    ServiceName,\r\n    podCount,\r\n    containerNotrunning,\r\n    containerNotrunningPercent = (containerNotrunning * 100 / podCount),\r\n    TimeGenerated,\r\n    PodStatus,\r\n    PodLabel,\r\n    Namespace,\r\n    Environment = tostring(split(ClusterName, '-')[3]),\r\n    Location = tostring(split(ClusterName, '-')[4]),\r\n    ContainerStatus,\r\n    ControllerKind,\r\n    Name,\r\n    Computer\r\n//Uncomment the below line to set for automated alert\r\n| where PodStatus == \"Running\" //and containerNotrunningPercent > _minalertThreshold and containerNotrunningPercent < _maxalertThreshold\r\n| summarize arg_max(TimeGenerated, *), c_entry=count() by PodLabel, ServiceName, ClusterName, ControllerKind, Name, Computer\r\n//Below lines are to parse the labels to identify the impacted service/component name\r\n| extend parseLabel = replace(@'k8s-app', @'k8sapp', PodLabel)\r\n| extend parseLabel = replace(@'app.kubernetes.io/component', @'appkubernetesiocomponent', parseLabel)\r\n| extend parseLabel = replace(@'app.kubernetes.io/instance', @'appkubernetesioinstance', parseLabel)\r\n| extend tags = todynamic(parseLabel)\r\n| extend tag01 = todynamic(tags[0].app)\r\n| extend tag02 = todynamic(tags[0].k8sapp)\r\n| extend tag03 = todynamic(tags[0].appkubernetesiocomponent)\r\n| extend tag04 = todynamic(tags[0].aadpodidbinding)\r\n| extend tag05 = todynamic(tags[0].appkubernetesioinstance)\r\n| extend tag06 = todynamic(tags[0].component)\r\n| extend ContainerRunning = 100 - containerNotrunningPercent\r\n| project ClusterName, TimeGenerated, ControllerKind, Name, Computer,\r\n    ServiceName = strcat(ServiceName, tag01, tag02, tag03, tag04, tag05, tag06),\r\n    ContainerUnavailable = strcat(\"Unavailable Percentage: \", containerNotrunningPercent),\r\n    ContainerRunning,\r\n    containerNotrunningPercent,\r\n    PodStatus = PodStatus, \r\n    ContainerStatus = ContainerStatus",
+                  "query": "let row = dynamic({row});\r\nKubePodInventory\r\n| where Name has strcat(\"{Application}\", \"-\")\r\n| where Computer in ({Computer})\r\n| where '{row}' == '{}' or (Name == row.PodName)\r\n//| where TimeGenerated >= ago(startDateTime)\r\n| where Namespace in('default', 'kube-system', 'nc-system', 'calico-system') // and ControllerKind == 'ReplicaSet' // the system namespace filter goes here\r\n| distinct\r\n    ClusterName,\r\n    Computer,\r\n    PodUid,\r\n    TimeGenerated,\r\n    PodStatus,\r\n    ServiceName,\r\n    PodLabel,\r\n    Namespace,\r\n    ContainerStatus,\r\n    Name,\r\n    ControllerKind\r\n| summarize\r\n    arg_max(TimeGenerated, *),\r\n    TotalPODCount = count(),\r\n    podCount = sumif(1, PodStatus == 'Running' or PodStatus != 'Running'),\r\n    containerNotrunning = sumif(1, ContainerStatus != 'running')\r\n    by\r\n    ClusterName,\r\n    TimeGenerated,\r\n    ServiceName,\r\n    PodLabel,\r\n    Namespace,\r\n    Name,\r\n    ControllerKind\r\n| project\r\n    ClusterName,\r\n    ServiceName,\r\n    podCount,\r\n    containerNotrunning,\r\n    containerNotrunningPercent = (containerNotrunning * 100 / podCount),\r\n    TimeGenerated,\r\n    PodStatus,\r\n    PodLabel,\r\n    Namespace,\r\n    Environment = tostring(split(ClusterName, '-')[3]),\r\n    Location = tostring(split(ClusterName, '-')[4]),\r\n    ContainerStatus,\r\n    ControllerKind,\r\n    Name,\r\n    Computer\r\n//Uncomment the below line to set for automated alert\r\n| where PodStatus == \"Running\" //and containerNotrunningPercent > _minalertThreshold and containerNotrunningPercent < _maxalertThreshold\r\n| summarize arg_max(TimeGenerated, *), c_entry=count() by PodLabel, ServiceName, ClusterName, ControllerKind, Name, Computer\r\n//Below lines are to parse the labels to identify the impacted service/component name\r\n| extend parseLabel = replace(@'k8s-app', @'k8sapp', PodLabel)\r\n| extend parseLabel = replace(@'app.kubernetes.io/component', @'appkubernetesiocomponent', parseLabel)\r\n| extend parseLabel = replace(@'app.kubernetes.io/instance', @'appkubernetesioinstance', parseLabel)\r\n| extend tags = todynamic(parseLabel)\r\n| extend tag01 = todynamic(tags[0].app)\r\n| extend tag02 = todynamic(tags[0].k8sapp)\r\n| extend tag03 = todynamic(tags[0].appkubernetesiocomponent)\r\n| extend tag04 = todynamic(tags[0].aadpodidbinding)\r\n| extend tag05 = todynamic(tags[0].appkubernetesioinstance)\r\n| extend tag06 = todynamic(tags[0].component)\r\n| extend ContainerRunning = 100 - containerNotrunningPercent\r\n| project ClusterName, TimeGenerated, ControllerKind, Name, Computer,\r\n    ServiceName = strcat(ServiceName, tag01, tag02, tag03, tag04, tag05, tag06),\r\n    ContainerUnavailable = strcat(\"Unavailable Percentage: \", containerNotrunningPercent),\r\n    ContainerRunning,\r\n    containerNotrunningPercent,\r\n    PodStatus = PodStatus, \r\n    ContainerStatus = ContainerStatus",
                   "size": 0,
                   "title": "Pod/Container Availability",
                   "timeContextFromParameter": "Timeframe",

--- a/Azure Services/Azure Operator Distributed Services/Workbooks/Preview/armTemplates/templates/node.json
+++ b/Azure Services/Azure Operator Distributed Services/Workbooks/Preview/armTemplates/templates/node.json
@@ -66,6 +66,7 @@
           "type": 9,
           "content": {
             "version": "KqlParameterItem/1.0",
+            "crossComponentResources": ["{Resource}"],
             "parameters": [
               {
                 "id": "ae41fa0f-4d3c-4e2b-b1b4-0a178a567c03",
@@ -159,22 +160,24 @@
                 "multiSelect": true,
                 "quote": "'",
                 "delimiter": ",",
-                "query": "Perf \r\n| summarize by Computer",
-                "value": ["value::all"],
+                "query": "InsightsMetrics\r\n| summarize by Computer\r\n| sort by Computer asc",
+                "crossComponentResources": ["{Resource}"],
                 "typeSettings": {
-                  "additionalResourceOptions": ["value::all"]
+                  "additionalResourceOptions": ["value::all"],
+                  "showDefault": false
                 },
                 "timeContext": {
                   "durationMs": 0
                 },
                 "timeContextFromParameter": "Timeframe",
                 "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces"
+                "resourceType": "microsoft.kubernetes/connectedclusters",
+                "value": ["value::all"]
               }
             ],
             "style": "above",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.kubernetes/connectedclusters"
           },
           "name": "Parameters"
         },
@@ -245,7 +248,7 @@
                       "type": 3,
                       "content": {
                         "version": "KqlItem/1.0",
-                        "query": "InsightsMetrics\r\n| where Namespace == 'prometheus' and Name has_cs 'node_cpu_seconds_total'\r\n| extend Tags = todynamic(Tags)\r\n| extend HostName = tostring(Tags.hostName)\r\n| summarize dcount(HostName)",
+                        "query": "InsightsMetrics\r\n| where Name startswith \"node_\"\r\n| summarize dcount(Computer)",
                         "size": 3,
                         "title": "Servers Connected",
                         "timeContextFromParameter": "Timeframe",
@@ -256,7 +259,7 @@
                         "tileSettings": {
                           "titleContent": {},
                           "leftContent": {
-                            "columnMatch": "dcount_HostName",
+                            "columnMatch": "dcount_Computer",
                             "formatter": 12,
                             "formatOptions": {
                               "palette": "auto"
@@ -449,7 +452,7 @@
                       "type": 3,
                       "content": {
                         "version": "KqlItem/1.0",
-                        "query": "let totalcount =  Heartbeat\r\n| where TimeGenerated {Timeframe:query}\r\n| where Computer in ({Computer})\r\n| summarize dcount(Computer);\r\n Heartbeat\r\n| where TimeGenerated {Timeframe:query}\r\n| where Computer in ({Computer})\r\n| summarize LastHeartbeat = max(TimeGenerated) by Computer\r\n| where LastHeartbeat < ago(1h)\r\n| summarize inactive=count()\r\n| project value=iff(inactive==0, strcat(\"All \", toscalar(totalcount) , \" nodes are active\") , strcat(tostring(inactive),\" out of \", tostring(toscalar(totalcount)), \" are inactive\" ))\r\n//| project value=strcat(\"3 out of 3 nodes are active\")",
+                        "query": "let totalcount =  Heartbeat\r\n| where Computer in ({Computer})\r\n| summarize dcount(Computer);\r\n Heartbeat\r\n| where Computer in ({Computer})\r\n| summarize LastHeartbeat = max(TimeGenerated) by Computer\r\n| where LastHeartbeat < ago(1h)\r\n| summarize inactive=count()\r\n| project value=iff(inactive==0, strcat(\"All \", toscalar(totalcount) , \" nodes are active\") , strcat(tostring(inactive),\" out of \", tostring(toscalar(totalcount)), \" are inactive\" ))\r\n//| project value=strcat(\"3 out of 3 nodes are active\")",
                         "size": 3,
                         "title": "Inactive Agents (missing heartbeats)",
                         "noDataMessage": "No inactive agents found",
@@ -526,12 +529,13 @@
                 "type": 3,
                 "content": {
                   "version": "KqlItem/1.0",
-                  "query": "InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_cpu_seconds_total'\r\n| extend Tags = todynamic(Tags)\r\n| extend HostName = tostring(Tags.hostName), Cpu = Tags.cpu, Mode = Tags.mode\r\n| where Mode == \"idle\"\r\n| extend NodeDisk = strcat(Mode, \"/\", Cpu, \"/\", HostName, \"/\", _ResourceId)\r\n| order by NodeDisk asc, TimeGenerated asc\r\n| serialize\r\n| extend PrevVal = iif(prev(NodeDisk) != NodeDisk, 0.0, prev(Val)), PrevTimeGenerated = iif(prev(NodeDisk) != NodeDisk, datetime(null), prev(TimeGenerated))\r\n| where isnotnull(PrevTimeGenerated) //and PrevTimeGenerated != TimeGenerated\r\n| extend Rate = iif(PrevVal > Val, Val / (datetime_diff('Second', TimeGenerated, PrevTimeGenerated) * 1), iif(PrevVal == Val, 0.0, (Val - PrevVal) / (datetime_diff('Second', TimeGenerated, PrevTimeGenerated) * 1)))\r\n//| where isnotnull(Rate)\r\n| project TimeGenerated, NodeDisk, Rate, HostName\r\n| summarize CpuUsage = 100 - (100 * avg(Rate)) by HostName\r\n//Perf\r\n//| where ObjectName == \"K8SNode\"  and CounterName contains \"cpuUsage\" \r\n//| summarize CounterValue = avg(CounterValue/1000000000) by Computer, _ResourceId\r\n//| extend ResourceGroup = extract(@'/subscriptions/.+/resourcegroups/(.+)/providers/microsoft.compute/virtualmachines/.+', 1, _ResourceId)\r\n//| extend ResourceGroup = iff(ResourceGroup == '', 'On-premise computers', ResourceGroup), Id = strcat(_ResourceId, '::', Computer)",
+                  "query": "InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_cpu_seconds_total'\r\n| extend Tags = todynamic(Tags)\r\n| extend HostName = tostring(Tags.hostName), Cpu = Tags.cpu, Mode = Tags.mode\r\n| where Mode == \"idle\"\r\n| extend NodeDisk = strcat(Mode, \"/\", Cpu, \"/\", HostName, \"/\", _ResourceId)\r\n| order by NodeDisk asc, TimeGenerated asc\r\n| serialize\r\n| extend PrevVal = iif(prev(NodeDisk) != NodeDisk, 0.0, prev(Val)), PrevTimeGenerated = iif(prev(NodeDisk) != NodeDisk, datetime(null), prev(TimeGenerated))\r\n| where isnotnull(PrevTimeGenerated) //and PrevTimeGenerated != TimeGenerated\r\n| extend Rate = iif(PrevVal > Val, Val / (datetime_diff('Second', TimeGenerated, PrevTimeGenerated) * 1), iif(PrevVal == Val, 0.0, (Val - PrevVal) / (datetime_diff('Second', TimeGenerated, PrevTimeGenerated) * 1)))\r\n//| where isnotnull(Rate)\r\n| project TimeGenerated, NodeDisk, Rate, HostName\r\n| summarize CpuUsage = 100 - (100 * avg(Rate)) by HostName",
                   "size": 0,
                   "title": "Heatmap for the CPU Process time of the nodes",
                   "timeContextFromParameter": "Timeframe",
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "resourceType": "microsoft.kubernetes/connectedclusters",
+                  "crossComponentResources": ["{Resource}"],
                   "visualization": "graph",
                   "graphSettings": {
                     "type": 2,
@@ -586,7 +590,8 @@
                   "title": "Heatmap for the Disk usage of the nodes",
                   "timeContextFromParameter": "Timeframe",
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "resourceType": "microsoft.kubernetes/connectedclusters",
+                  "crossComponentResources": ["{Resource}"],
                   "visualization": "graph",
                   "graphSettings": {
                     "type": 2,
@@ -641,7 +646,8 @@
                   "title": "Heatmap for the Memory usage of the nodes",
                   "timeContextFromParameter": "Timeframe",
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "resourceType": "microsoft.kubernetes/connectedclusters",
+                  "crossComponentResources": ["{Resource}"],
                   "visualization": "graph",
                   "graphSettings": {
                     "type": 2,
@@ -690,7 +696,7 @@
               {
                 "type": 1,
                 "content": {
-                  "json": "### 💡 _Above heatmaps shows an average over the timeframe selected._ "
+                  "json": "### 💡 _Above heatmaps show an average over the timeframe selected._ "
                 },
                 "name": "text - 13 - Copy"
               },
@@ -815,18 +821,20 @@
                 "content": {
                   "version": "NotebookGroup/1.0",
                   "groupType": "editable",
-                  "title": "Disk Status",
+                  "title": "FileSystem Status",
                   "items": [
                     {
                       "type": 3,
                       "content": {
                         "version": "KqlItem/1.0",
-                        "query": "let usedDiskUnhealthyThreshold = 90;\r\nlet usedDiskCriticalThreshold = 99;\r\nlet diskfree = InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_avail_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize Disk_Free=min(Val) by NodeDisk;\r\nlet data = materialize(InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_size_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize Disk_Total = avg(Val) by  NodeDisk\r\n| join diskfree on  NodeDisk\r\n| extend Disk_Used = 100 - (100 * (Disk_Free / Disk_Total ))\r\n//| project-away hostname1, device1\r\n| extend State = iff(Disk_Used >= usedDiskCriticalThreshold, 'Critical disks', iif((Disk_Used >= usedDiskUnhealthyThreshold and Disk_Used < usedDiskCriticalThreshold), 'Unhealthy disks', 'Healthy disks'))\r\n);\r\ndata\r\n| summarize Count = count(), Disks = makeset(NodeDisk) by State\r\n| union (\r\n    data\r\n    | summarize Count = count(), Disks = dynamic([\"*\"])\r\n    | extend State = 'All disks'\r\n)\r\n| join kind = fullouter (datatable (State: string) ['All disks', 'Critical disks', 'Unhealthy disks', 'Healthy disks']) on State\r\n| extend Count = iff(State == '', 0, Count), Disks = iff(State == '', dynamic([]), Disks)\r\n| order by Count desc",
+                        "query": "let usedDiskUnhealthyThreshold = 90;\r\nlet usedDiskCriticalThreshold = 99;\r\nlet diskfree = InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_avail_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize Disk_Free=min(Val) by NodeDisk;\r\nlet data = materialize(InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_size_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize Disk_Total = avg(Val) by  NodeDisk\r\n| join diskfree on  NodeDisk\r\n| extend Disk_Used = 100 - (100 * (Disk_Free / Disk_Total ))\r\n//| project-away hostname1, device1\r\n| extend State = iff(Disk_Used >= usedDiskCriticalThreshold, 'Critical FileSystems', iif((Disk_Used >= usedDiskUnhealthyThreshold and Disk_Used < usedDiskCriticalThreshold), 'Unhealthy FileSystems', 'Healthy FileSystems'))\r\n);\r\ndata\r\n| summarize Count = count(), Disks = makeset(NodeDisk) by State\r\n| union (\r\n    data\r\n    | summarize Count = count(), Disks = dynamic([\"*\"])\r\n    | extend State = 'All FileSystems'\r\n)\r\n| join kind = fullouter (datatable (State: string) ['All FileSystems', 'Critical FileSystems', 'Unhealthy FileSystems', 'Healthy FileSystems']) on State\r\n| extend Count = iff(State == '', 0, Count), Disks = iff(State == '', dynamic([]), Disks)\r\n| order by Count desc",
                         "size": 4,
                         "aggregation": 2,
+                        "timeContextFromParameter": "Timeframe",
                         "timeBrushParameterName": "filteredTimeRange",
                         "queryType": 0,
-                        "resourceType": "microsoft.operationalinsights/workspaces",
+                        "resourceType": "microsoft.kubernetes/connectedclusters",
+                        "crossComponentResources": ["{Resource}"],
                         "visualization": "tiles",
                         "tileSettings": {
                           "titleContent": {
@@ -841,19 +849,19 @@
                               "thresholdsGrid": [
                                 {
                                   "operator": "==",
-                                  "thresholdValue": "Critical disks",
+                                  "thresholdValue": "Critical FileSystems",
                                   "representation": "4",
                                   "text": ""
                                 },
                                 {
                                   "operator": "==",
-                                  "thresholdValue": "Unhealthy disks",
+                                  "thresholdValue": "Unhealthy FileSystems",
                                   "representation": "2",
                                   "text": ""
                                 },
                                 {
                                   "operator": "==",
-                                  "thresholdValue": "Healthy disks",
+                                  "thresholdValue": "Healthy FileSystems",
                                   "representation": "success",
                                   "text": ""
                                 },
@@ -896,7 +904,7 @@
                       "type": 3,
                       "content": {
                         "version": "KqlItem/1.0",
-                        "query": "let usedDiskUnhealthyThreshold = 90;\r\nlet usedDiskCriticalThreshold = 99;\r\nlet diskfree = InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_avail_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize Disk_Free=min(Val) by hostname,device;\r\nInsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_size_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize Disk_Total = avg(Val) by  hostname,device\r\n| join diskfree on  hostname,device\r\n| extend Disk_Used = 100 - (100 * (Disk_Free / Disk_Total ))\r\n| project-away hostname1, device1\r\n| extend  hostname = strcat('🖥️ ',  hostname)\r\n| extend State = iff(Disk_Used >= usedDiskCriticalThreshold, 'Critical disks', iif((Disk_Used >= usedDiskUnhealthyThreshold and Disk_Used < usedDiskCriticalThreshold), 'Unhealthy disks', 'Healthy disks'))\r\n",
+                        "query": "let usedFileSystemUnhealthyThreshold = 90;\r\nlet usedFileSystemCriticalThreshold = 99;\r\nlet FileSystemfree = InsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_avail_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize FileSystem_Free=min(Val) by hostname,device;\r\nInsightsMetrics\r\n| where Namespace == 'prometheus' and Name contains 'node_filesystem_size_bytes'\r\n| extend Json = parse_json(Tags)\r\n| extend hostname = tostring(Json.hostName), device = tostring(Json.device)\r\n| extend NodeDisk = strcat(hostname, \"/\", device)\r\n| where hostname in ({Computer})\r\n| summarize FileSystem_Total = avg(Val) by  hostname,device\r\n| join FileSystemfree on  hostname,device\r\n| extend FileSystem_Used = 100 - (100 * (FileSystem_Free / FileSystem_Total ))\r\n| project-away hostname1, device1\r\n| extend  hostname = strcat('🖥️ ',  hostname)\r\n| extend State = iff(FileSystem_Used >= usedFileSystemCriticalThreshold, 'Critical FileSystems', iif((FileSystem_Used >= usedFileSystemUnhealthyThreshold and FileSystem_Used < usedFileSystemCriticalThreshold), 'Unhealthy FileSystems', 'Healthy FileSystems'))\r\n",
                         "size": 3,
                         "timeContextFromParameter": "Timeframe",
                         "queryType": 0,
@@ -1165,7 +1173,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 86400000
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1212,7 +1220,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 86400000
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1259,7 +1267,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 86400000
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1306,7 +1314,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 86400000
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1373,7 +1381,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 0
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1429,7 +1437,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 0
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1463,7 +1471,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 86400000
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {
@@ -1497,7 +1505,7 @@
                         "resourceIds": ["{Resource}"],
                         "timeContextFromParameter": "Timeframe",
                         "timeContext": {
-                          "durationMs": 86400000
+                          "durationMs": 1800000
                         },
                         "metrics": [
                           {


### PR DESCRIPTION
1. Node Workbook changes:

- Fix node count & heartbeat from same table to avoid discrepancies
- Update Filesystem info to show Filesystem instead of Disk
- Updating the timeframe parameter for the Filesystem chart, will perhaps solve the ADX query timeout issue

2. Controlplane workbook changes:

- Update Container Status table to add ContainerName, ContainerStatusReason
- Add calico-system namespace for one calico application
- Fix Ingestion Volume tab viewing