### PR TITLE
Remove resource health alert rule for Arc servers

### DIFF
--- a/Azure Services/Azure Operator Nexus/Alerts/Preview/armTemplates/activityLogAlerts/arcKubernetes.json
+++ b/Azure Services/Azure Operator Nexus/Alerts/Preview/armTemplates/activityLogAlerts/arcKubernetes.json
@@ -3,10 +3,13 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "alertName": {
-      "value": "Arc Resource Disconnected"
+      "value": "Arc Kubernetes Disconnected"
     },
     "alertDescription": {
-      "value": "Resource is disconnected from Arc"
+      "value": "Kubernetes cluster is disconnected from Arc"
+    },
+    "resourceType": {
+      "value": "microsoft.kubernetes/connectedclusters"
     }
   }
 }

--- a/Azure Services/Azure Operator Nexus/Alerts/Preview/armTemplates/templates/activityLogAlerts.bicep
+++ b/Azure Services/Azure Operator Nexus/Alerts/Preview/armTemplates/templates/activityLogAlerts.bicep
@@ -19,6 +19,10 @@ param isEnabled bool = true
 @minLength(1)
 param resourceGroup string
 
+@description('Resource type of the alert')
+@minLength(1)
+param resourceType string
+
 resource alertName_resource 'microsoft.insights/activitylogalerts@2020-10-01' = {
   name: alertName
   location: 'global'
@@ -82,11 +86,7 @@ resource alertName_resource 'microsoft.insights/activitylogalerts@2020-10-01' = 
           anyOf: [
             {
               field: 'resourceType'
-              equals: 'microsoft.hybridcompute/machines'
-            }
-            {
-              field: 'resourceType'
-              equals: 'microsoft.kubernetes/connectedclusters'
+              equals: resourceType
             }
           ]
         }

--- a/Azure Services/Azure Operator Nexus/README.md
+++ b/Azure Services/Azure Operator Nexus/README.md
@@ -101,7 +101,7 @@ run to create alert rules.
 
 AzureMonitorCommunity repository path:  **`Alerts/Preview/armTemplates`**
 
-- `deployActivityLogAlerts.sh` - Shell script utility for creating resource health alerts on Arc connected Kubernetes/Servers
+- `deployActivityLogAlerts.sh` - Shell script utility for creating resource health alerts on Arc connected Kubernetes cluster
 - `deployMetricAlerts.sh` - Shell script utility for creating metric alert rules on an AzON cluster
 - `deployScheduledQueryRules.sh` - Shell script utility for creating log alert rules on a Log Analytics Workspace
 - `/templates` - Folder contains ARM templates for use in deploying
@@ -234,7 +234,7 @@ You can run the script from the alert rules folder:
 
 #### **Resource Health Alert Rules**
 
-You can apply Resource health alert rules to an Arc-Connected K8s Cluster and Servers. To deploy a single sample resource health alert rule using the following command:
+You can apply Resource health alert rules to an Arc-Connected K8s Cluster. To deploy a single sample resource health alert rule using the following command:
 
 ```sh
   az deployment group create \
@@ -253,7 +253,7 @@ where
 - **<RESOURCE_GROUP>** = resource group where the Arc connected resource exists. Alert rules will also be created in this Resource Group.
 - **<PATH_TO_TEMPLATE_FILE>** = path to `templates/activityLogAlerts.bicep`
 - **<PATH_TO_PARAMETER_FILE>** = path to parameter file in `activityLogAlerts/` for alert rule to be created
-- **<SUBSCRIPTION_ID>** = subscription ID where target resource (Arc Kubernetes/Server) lives
+- **<SUBSCRIPTION_ID>** = subscription ID where target resource (Arc Kubernetes) lives
 - **<ACTION_GROUP_IDS>** = optional comma-separated list of Action Group resource IDs to be associated to the alert rule.
 - **<PARAM_NAME>="<PARAM_VALUE>"** = Optional name/value pairs, which can override other parameter file values
 


### PR DESCRIPTION
Remove resource health alert rule for Arc servers as customers will end up getting a huge number of alerts for a single disconnection.