### PR TITLE
Update S2S tunnel connetdisconnect events.kql (typo fix)

### DIFF
--- a/Azure Services/Virtual Network Gateways/Queries/VPN Gateway/S2S tunnel connetdisconnect events.kql
+++ b/Azure Services/Virtual Network Gateways/Queries/VPN Gateway/S2S tunnel connetdisconnect events.kql
@@ -1,6 +1,6 @@
 // Author: Microsoft Azure
-// Display name: S2S tunnel connet/disconnect events
-// Description: S2S tunnel connet/disconnect events during the last 24 hours.
+// Display name: S2S tunnel connect/disconnect events
+// Description: S2S tunnel connect/disconnect events during the last 24 hours.
 // Categories: Network
 // Resource types: Virtual Network Gateways
 // Topic: VPN Gateway


### PR DESCRIPTION
This built-in query is displayed in the portal UI with a typo - "connet" vs. "connect"

![image](https://github.com/microsoft/AzureMonitorCommunity/assets/576449/7694cd2e-fe92-4e01-bb07-720ba4806fe7)
