### PR TITLE
Update Activity Runs Availability.kql

### DIFF
--- a/Azure Services/Data factories/Queries/Availability/Activity Runs Availability.kql
+++ b/Azure Services/Data factories/Queries/Availability/Activity Runs Availability.kql
@@ -8,6 +8,6 @@
 ADFActivityRun    
 | where Status != 'InProgress' and Status != 'Queued'
 | where FailureType != 'UserError'
-| summarize availability = 100.00 - (100.00*countif(Status != 'Succeeded') / count())  by bin(TimeGenerated, 1h)), _ResourceId
+| summarize availability = 100.00 - (100.00*countif(Status != 'Succeeded') / count())  by bin(TimeGenerated, 1h), _ResourceId
 | order by TimeGenerated asc
 | render timechart


### PR DESCRIPTION
Example query in Azure Datafactory for Activity run availability throws syntax error.

Fix for that issue is made in this changes