### PR TITLE
Bug fix for WorkspaceConfigToDCRMigrationTool.ps1

### DIFF
--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/WorkspaceConfigToDCRMigrationTool.ps1
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/WorkspaceConfigToDCRMigrationTool.ps1
@@ -630,7 +630,7 @@ function Get-ExtensionDataSources
         $state.runtime.dcrTypesEnabled.extensions = $true
 
         # Extensions DCR output updates
-        $state.outputs.windows.parameters.dcrName.defaultValue = $DcrName + "-extensions"
+        $state.outputs.extensions.parameters.dcrName.defaultValue = $DcrName + "-extensions"
         $state.outputs.extensions.parameters.dcrLocation.defaultValue = $state.runtime.dcrLocation
         $state.outputs.extensions.resources[0].properties.description = "Azure monitor migration script generated extensions rule"
         $state.outputs.extensions.resources[0].properties.dataSources["performanceCounters"] = @()


### PR DESCRIPTION
Fixed a bug where generating extensions ARM template would modify dcrName.defaultValue of Windows DCR template to basename + "-extension" instead of setting the dcrName.defaultValue in the Extensions DCR ARM template