### PR TITLE
Fixed typo in diagnostic query "Windows Firewall policy settings changed by machines"

### DIFF
--- a/Solutions/LogManagement/Queries/Diagnostics/Windows Firewall policy settings changed by machines.kql
+++ b/Solutions/LogManagement/Queries/Diagnostics/Windows Firewall policy settings changed by machines.kql
@@ -1,6 +1,6 @@
 // Author: Microsoft Azure
-// Display name: Windows Fireawall policy settings changed by machines
-// Description: Windows Fireawall policy settings changed by machines.
+// Display name: Windows Firewall policy settings changed by machines
+// Description: Windows Firewall policy settings changed by machines.
 // Categories: virtualmachines
 // Solutions: LogManagement
 // Topic: Diagnostics

--- a/Solutions/LogManagement/Queries/Diagnostics/Windows Firewall policy settings.kql
+++ b/Solutions/LogManagement/Queries/Diagnostics/Windows Firewall policy settings.kql
@@ -1,6 +1,6 @@
 // Author: Microsoft Azure
-// Display name: Windows Fireawall policy settings
-// Description: Windows Fireawall policy settings changed.
+// Display name: Windows Firewall policy settings
+// Description: Windows Firewall policy settings changed.
 // Categories: virtualmachines
 // Solutions: LogManagement
 // Topic: Diagnostics


### PR DESCRIPTION
Fixed typo in diagnostic query "Windows Firewall policy settings changed by machines"