### PR TITLE
dev box - billing consumed compute queries

### DIFF
--- a/Azure Services/Dev Box/Alerts/README
+++ b/Azure Services/Dev Box/Alerts/README
@@ -1,0 +1,1 @@
+Put alerts in this folder

--- a/Azure Services/Dev Box/Queries/README
+++ b/Azure Services/Dev Box/Queries/README
@@ -1,0 +1,1 @@
+Put queries in this folder

--- a/Azure Services/Dev Box/Queries/consumed compute per user.kql
+++ b/Azure Services/Dev Box/Queries/consumed compute per user.kql
@@ -1,0 +1,11 @@
+// Author: Microsoft Azure
+// Display name: Consumed compute per user
+// Description: Display consumed compute per user in hours
+// Categories: Azure Resources
+// Resource types: Dev Box
+// Topic: Dev Box Billing
+
+DevCenterBillingEventLogs 
+| where UsageType == "Compute"
+| summarize Horas=sum(Quantity) by UserId
+| render columnchart 

--- a/Azure Services/Dev Box/Workbooks/README
+++ b/Azure Services/Dev Box/Workbooks/README
@@ -1,0 +1,1 @@
+Put workbooks in this folder


### PR DESCRIPTION
Adding queries of Microsoft Dev Box. 
In this query, it shows in a column chart quantity of compute of each user consumed. Very useful to chargeback or even just verify the devs activity.
![computePerUser](https://github.com/user-attachments/assets/c3f4a559-fbe3-4194-942d-b6893478e22f)
