### PR TITLE
Add Usage Queries for Copilot Studio

### DIFF
--- a/Azure Services/Power Platform/Microsoft Copilot Studio/Queries/Most_Used_Topics.kql
+++ b/Azure Services/Power Platform/Microsoft Copilot Studio/Queries/Most_Used_Topics.kql
@@ -1,0 +1,10 @@
+// Author: Ali Youssefi
+// Display name: Display most used topics by agent in Copilot Studio
+// Description: Summary of most used topics displaying the topic name, number of invocations by agent.
+// Categories: Power Platform
+// Resource types: Copilot Studio
+// Topic:  Usage Analytics
+customEvents
+| where name == 'TopicStart'
+| summarize NumOfTopic = count() by tostring(customDimensions.TopicName), cloud_RoleInstance
+| where NumOfTopic > 1


### PR DESCRIPTION
This pull request introduces a new KQL query to analyze usage data in Copilot Studio. The query identifies the most used topics by agents, providing insights into topic popularity and agent activity.

### New KQL Query for Usage Analytics:

* [`Azure Services/Power Platform/Microsoft Copilot Studio/Queries/Most_Used_Topics.kql`](diffhunk://#diff-596e15a95d4bdb958a780876d1e902515a7468fc58bd2cb90d67297e5951ecb9R1-R10): Added a query to summarize the most used topics by counting invocations (`TopicStart`) grouped by topic name and agent (`cloud_RoleInstance`). The query filters out topics with only one invocation. Metadata such as author, display name, description, and categories were also added for better organization and discoverability.