### PR TITLE
Add KQL query for hits by rule collection

### DIFF
--- a/Azure Services/Firewalls/Queries/Firewall Logs/Hits by rule collection.kql
+++ b/Azure Services/Firewalls/Queries/Firewall Logs/Hits by rule collection.kql
@@ -1,0 +1,11 @@
+// Author: tabasco-dev
+// Display name: Hits by rule collection
+// Description: Counts number of hits by rule collection during specific period of time
+// Categories: Network
+// Resource types: Firewalls
+// Topic: Firewall Logs
+
+AZFWNetworkRule 
+| where TimeGenerated between (datetime('2026-02-10T11:40:00Z') .. datetime('2026-02-10T11:42:00Z'))
+| summarize Hits = count() by Rule, RuleCollection, Action
+| top 20 by Hits desc


### PR DESCRIPTION
This query counts the number of hits by rule collection for Azure Firewall during a specified time period.