### PR TITLE
Fix InvalidAuthenticationToken error for Az.Accounts >= 5.0.0 (Az >= 14.0.0) in DCR Migration Tool

### DIFF
--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/CHANGELOG.md
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the script will be documented in this file.
 ## [1.0.2] - 2026-02-17
 
 ### Fixed
-- Fixed `InvalidAuthenticationToken` error caused by Az.Accounts >= 2.13.0 breaking change where `Get-AzAccessToken` returns a `SecureString` instead of a plain string. Added `Get-AzAccessTokenPlainText` helper that handles both old and new Az module versions.
+- Fixed `InvalidAuthenticationToken` error caused by Az.Accounts >= 5.0.0 (Az >= 14.0.0) breaking change where `Get-AzAccessToken` returns a `SecureString` instead of a plain string. Added `Get-AzAccessTokenPlainText` helper that handles both old and new Az module versions.
 
 ### Changed
 - Updated the Data Collection Endpoint (DCE) API version from `2022-06-01` to `2023-03-11`.

--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/CHANGELOG.md
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the script will be documented in this file.
 
+## [1.0.2] - 2026-02-17
+
+### Fixed
+- Fixed `InvalidAuthenticationToken` error caused by Az.Accounts >= 2.13.0 breaking change where `Get-AzAccessToken` returns a `SecureString` instead of a plain string. Added `Get-AzAccessTokenPlainText` helper that handles both old and new Az module versions.
+
+### Changed
+- Updated the Data Collection Endpoint (DCE) API version from `2022-06-01` to `2023-03-11`.
+
 ## [1.0.1] - 2024-08-01
 
 ### Changed

--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/README.md
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/README.md
@@ -12,7 +12,7 @@ It is a standalone script and doesn't require the installation of any additional
 
 - `Powershell version 7.1.3` or higher is recommended (minimum version 5.1)
 - Primarily uses `Az Powershell module` to pull workspace agent configuration information (https://learn.microsoft.com/en-us/powershell/azure/install-azps-windows?view=azps-11.0.0&tabs=powershell&pivots=windows-psgallery)
-- Compatible with both older Az.Accounts modules and **Az.Accounts >= 2.13.0** (which changed `Get-AzAccessToken` to return a `SecureString`)
+- Compatible with both older Az.Accounts modules and **Az.Accounts >= 5.0.0 (Az >= 14.0.0)** (which changed `Get-AzAccessToken` to return a `SecureString`)
 - User will need Read/Write access to the specified workspace resource
 - Connect-AzAccount and Select-AzSubscription will be used to set the context for the script to run so proper Azure credentials will be needed
 

--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/README.md
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/README.md
@@ -12,6 +12,7 @@ It is a standalone script and doesn't require the installation of any additional
 
 - `Powershell version 7.1.3` or higher is recommended (minimum version 5.1)
 - Primarily uses `Az Powershell module` to pull workspace agent configuration information (https://learn.microsoft.com/en-us/powershell/azure/install-azps-windows?view=azps-11.0.0&tabs=powershell&pivots=windows-psgallery)
+- Compatible with both older Az.Accounts modules and **Az.Accounts >= 2.13.0** (which changed `Get-AzAccessToken` to return a `SecureString`)
 - User will need Read/Write access to the specified workspace resource
 - Connect-AzAccount and Select-AzSubscription will be used to set the context for the script to run so proper Azure credentials will be needed
 

--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/WorkspaceConfigToDCRMigrationTool.ps1
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/WorkspaceConfigToDCRMigrationTool.ps1
@@ -102,7 +102,7 @@ function Set-ValidateOutputFolder
 .DESCRIPTION
     Gets a plain-text access token for Azure Management API.
     Handles both old (string) and new (SecureString) versions of Get-AzAccessToken.
-    In Az.Accounts >= 2.13.0, the .Token property returns a SecureString instead of a plain string.
+    In Az.Accounts >= 5.0.0 (Az >= 14.0.0), the .Token property returns a SecureString instead of a plain string.
 #>
 function Get-AzAccessTokenPlainText
 {
@@ -111,7 +111,7 @@ function Get-AzAccessTokenPlainText
 
     if ($tokenObj.Token -is [System.Security.SecureString])
     {
-        # Az.Accounts >= 2.13.0 returns SecureString
+        # Az.Accounts >= 5.0.0 (Az >= 14.0.0) returns SecureString
         $plainToken = $tokenObj.Token | ConvertFrom-SecureString -AsPlainText
     }
     else

--- a/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/WorkspaceConfigToDCRMigrationTool.ps1
+++ b/Azure Services/Azure Monitor/Agents/Migration Tools/DCR Config Generator/WorkspaceConfigToDCRMigrationTool.ps1
@@ -65,7 +65,7 @@ function Get-Greetings
 ####        where we help you step into the world of AMA and DCR      ####
 ####                                                                  ####
 ####                                                                  ####
-####             Azure Monitor Control Plane, August 2024             ####
+####             Azure Monitor Control Plane, February 2026           ####
 ##########################################################################
 
 "@
@@ -823,19 +823,19 @@ function Get-CustomLogs
 
         $filePatterns = @()
 
-        foreach ($input in $customLog.Properties.Inputs)
+        foreach ($inputEntry in $customLog.Properties.Inputs)
         {
-            if($null -ne $input.location.fileSystemLocations.linuxFileTypeLogPaths)
+            if($null -ne $inputEntry.location.fileSystemLocations.linuxFileTypeLogPaths)
             {
-                foreach ($linuxPath in $input.location.fileSystemLocations.linuxFileTypeLogPaths)
+                foreach ($linuxPath in $inputEntry.location.fileSystemLocations.linuxFileTypeLogPaths)
                 {
                     $filePatterns += $linuxPath
                 }
             }
 
-            if($null -ne $input.location.fileSystemLocations.windowsFileTypeLogPaths)
+            if($null -ne $inputEntry.location.fileSystemLocations.windowsFileTypeLogPaths)
             {
-                foreach ($windowsPath in $input.location.fileSystemLocations.windowsFileTypeLogPaths)
+                foreach ($windowsPath in $inputEntry.location.fileSystemLocations.windowsFileTypeLogPaths)
                 {
                     $windowsPathCorrected = $windowsPath.Replace("\\", "\")
                     $filePatterns += $windowsPathCorrected
@@ -889,7 +889,7 @@ function Get-CustomLogs
             $customStreamName = "Custom-Input-$($customLog.Properties.customLogName)"
             $outputStreamName = "Custom-$($customLog.Properties.customLogName)"
             $clArmTemplate.resources[0].properties["streamDeclarations"] = @{ 
-                $customStreamName = [ordered]@{ #Usinfg the default schema - Cx should update this to fit their use case
+                $customStreamName = [ordered]@{ #Using the default schema - Cx should update this to fit their use case
                     "columns" = @(
                         @{
                             "name" = "TimeGenerated";


### PR DESCRIPTION
## Summary

Fixes the `InvalidAuthenticationToken` / "The access token is invalid" error that occurs when running the DCR Config Generator script with **Az.Accounts >= 2.13.0**.

## Problem

In Az.Accounts 2.13.0, `Get-AzAccessToken` introduced a breaking change — the `.Token` property now returns a `SecureString` instead of a plain `string`. When interpolated into the `Authorization: Bearer` header, the `SecureString` object reference was sent instead of the actual token, causing all ARM API calls to fail with:

```json
{ "error": { "code": "InvalidAuthenticationToken", "message": "The access token is invalid." } }